### PR TITLE
ユーザーフォームに入力したものをDBに追加してリダイレクトする部分の実装

### DIFF
--- a/ginstagram/templates/ginstagram/profile.html
+++ b/ginstagram/templates/ginstagram/profile.html
@@ -6,7 +6,6 @@
   <!-- アカウント情報 -->
   <div class="row">
     <div class="col-md-2 col-md-offset-1">
-      <img src="{{userInfo.icon.url}}" class="ginstagram-icon img-responsive ">
 
     </div>
     <div class="col-md-9">

--- a/ginstagram/templates/ginstagram/registration.html
+++ b/ginstagram/templates/ginstagram/registration.html
@@ -5,7 +5,8 @@
 <div class=" panel panel-primary" >
     <div class="panel-heading">登録フォーム</div>
     <div class="panel-body">
-    <form>
+    <form action="{% url 'ginstagram:registration' %}" method="post">
+        {% csrf_token %}
         <div class="form-group">
             <label for="username">ユーザーネーム</label>
             <input type="text" name="username" id="username"/>

--- a/ginstagram/templates/ginstagram/registration.html
+++ b/ginstagram/templates/ginstagram/registration.html
@@ -2,24 +2,26 @@
 {% block title %}Ginstagram{%endblock%}
 {% block content %}
 <div class="container">
-<div class=" panel panel-primary" >
-    <div class="panel-heading">登録フォーム</div>
-    <div class="panel-body">
-    <form action="{% url 'ginstagram:registration' %}" method="post">
-        {% csrf_token %}
-        <div class="form-group">
-            <label for="username">ユーザーネーム</label>
-            <input type="text" name="username" id="username"/>
+    <div class=" panel panel-primary" >
+        <div class="panel-heading">
+            登録フォーム
         </div>
-        <div class="form-group">
-            <label for="password">パスワード</label>
-            <input type="password" name="password" id="password"/>
+        <div class="panel-body">
+            <form action="{% url 'ginstagram:registration' %}" method="post">
+                {% csrf_token %}
+                <div class="form-group">
+                    <label for="username">ユーザーネーム</label>
+                    <input type="text" name="username" id="username"/>
+                </div>
+                <div class="form-group">
+                    <label for="password">パスワード</label>
+                    <input type="password" name="password" id="password"/>
+                </div>
+                <div class="form-group">
+                    <button type="submit" class="btn btn-primary">登録</button>
+                </div>
+            </form>
         </div>
-        <div class="form-group">
-            <button type="submit" class="btn btn-primary">登録</button>
-        </div>
-    </form>
-</div>
-</div>
+    </div>
 </div>
 {%endblock%}

--- a/ginstagram/tests.py
+++ b/ginstagram/tests.py
@@ -47,3 +47,15 @@ class ユーザー作成機能(TestCase):
             reverse('ginstagram:registration')
         )
         self.assertContains(response, '<button type="submit"')
+
+    def test_ユーザー名とパスワードをPOSTで送信するとステータスコード200を返す(self):
+        response = self.client.post(
+            reverse('ginstagram:registration'), 
+            {
+                'username': 'TEST_USER_NAME',
+                'password': 'TEST_PASSWORD',
+            }
+        )
+        self.assertEqual(response.status_code, 200)
+
+

--- a/ginstagram/tests.py
+++ b/ginstagram/tests.py
@@ -16,60 +16,48 @@ class ユーザー詳細表示機能(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, user.username)
 
-class ユーザー作成機能(TestCase):
+class ユーザー作成フォームの表示(TestCase):
+
+    def setUp(self):
+        self.response = self.client.get(
+            reverse('ginstagram:registration')
+        )
 
     def test_IDとパスワードが入力できるformを表示する(self):
-        response = self.client.get(
-            reverse('ginstagram:registration')
-        )
-        self.assertEqual(response.status_code, 200) 
+        self.assertEqual(self.response.status_code, 200) 
 
     def test_ユーザー登録formを表示する(self):
-        response = self.client.get(
-            reverse('ginstagram:registration')
-        )
-        self.assertContains(response, '<form')
+        self.assertContains(self.response, '<form')
 
     def test_ユーザー登録でusernameの入力フォームを表示する(self):
-        response = self.client.get(
-            reverse('ginstagram:registration')
-        )
-        self.assertContains(response, '<input type="text" name="username"')
+        self.assertContains(self.response, '<input type="text" name="username"')
 
     def test_ユーザー登録でpasswordの入力フォームを表示する(self):
-        response = self.client.get(
-            reverse('ginstagram:registration')
-        )
-        self.assertContains(response, '<input type="password" name="password"')
+        self.assertContains(self.response, '<input type="password" name="password"')
 
     def test_ユーザー登録でsubmitボタンを表示する(self):
-        response = self.client.get(
-            reverse('ginstagram:registration')
+        self.assertContains(self.response, '<button type="submit"')
+
+class ユーザーフォームからPOSTしたらユーザー作成(TestCase):
+
+    def setUp(self):
+        self.username = 'TEST_USER_NAME'
+        self.password = 'TEST_PASSWORD'
+        self.response = self.client.post(
+            reverse('ginstagram:registration'), 
+            {
+                'username': self.username,
+                'password': self.password,
+            }
         )
-        self.assertContains(response, '<button type="submit"')
 
     def test_POSTで送信したIDとパスワードでDBにレコードを作成する(self):
-        response = self.client.post(
-            reverse('ginstagram:registration'), 
-            {
-                'username': 'TEST_USER_NAME',
-                'password': 'TEST_PASSWORD',
-            }
-        )
         user = Users.objects.last()
-        self.assertEqual(user.username, 'TEST_USER_NAME')
-        self.assertEqual(user.password, 'TEST_PASSWORD')
+        self.assertEqual(user.username, self.username)
+        self.assertEqual(user.password, self.password)
 
     def test_ユーザ作成成功後は作成したユーザ詳細画面にRedirectする(self):
-        response = self.client.post(
-            reverse('ginstagram:registration'), 
-            {
-                'username': 'TEST_USER_NAME',
-                'password': 'TEST_PASSWORD',
-            }
-        )
         self.assertRedirects(
-            response,
-            reverse('ginstagram:profile', kwargs={'username': 'TEST_USER_NAME'}),
+            self.response,
+            reverse('ginstagram:profile', kwargs={'username': self.username}),
         )
-    

--- a/ginstagram/tests.py
+++ b/ginstagram/tests.py
@@ -48,16 +48,6 @@ class ユーザー作成機能(TestCase):
         )
         self.assertContains(response, '<button type="submit"')
 
-    def test_ユーザー名とパスワードをPOSTで送信するとステータスコード200を返す(self):
-        response = self.client.post(
-            reverse('ginstagram:registration'), 
-            {
-                'username': 'TEST_USER_NAME',
-                'password': 'TEST_PASSWORD',
-            }
-        )
-        self.assertEqual(response.status_code, 200)
-
     def test_POSTで送信したIDとパスワードでDBにレコードを作成する(self):
         response = self.client.post(
             reverse('ginstagram:registration'), 
@@ -70,3 +60,13 @@ class ユーザー作成機能(TestCase):
         self.assertEqual(user.username, 'TEST_USER_NAME')
         self.assertEqual(user.password, 'TEST_PASSWORD')
 
+    def test_ユーザ作成成功後は作成したユーザ詳細画面にRedirectする(self):
+        response = self.client.post(
+            reverse('ginstagram:registration'), 
+            {
+                'username': 'TEST_USER_NAME',
+                'password': 'TEST_PASSWORD',
+            }
+        )
+        self.assertRedirects(response, '/TEST_USER_NAME/')
+    

--- a/ginstagram/tests.py
+++ b/ginstagram/tests.py
@@ -68,5 +68,8 @@ class ユーザー作成機能(TestCase):
                 'password': 'TEST_PASSWORD',
             }
         )
-        self.assertRedirects(response, '/TEST_USER_NAME/')
+        self.assertRedirects(
+            response,
+            reverse('ginstagram:profile', kwargs={'username': 'TEST_USER_NAME'}),
+        )
     

--- a/ginstagram/tests.py
+++ b/ginstagram/tests.py
@@ -58,4 +58,13 @@ class ユーザー作成機能(TestCase):
         )
         self.assertEqual(response.status_code, 200)
 
-
+    def test_DBに入力したIDとパスワードのレコードを作成する(self):
+        response = self.client.post(
+            reverse('ginstagram:registration'), 
+            {
+                'username': 'TEST_USER_NAME',
+                'password': 'TEST_PASSWORD',
+            }
+        )
+        user = Users.objects.last()
+        self.assertEqual(user.username, 'TEST_USER_NAME')

--- a/ginstagram/tests.py
+++ b/ginstagram/tests.py
@@ -58,7 +58,7 @@ class ユーザー作成機能(TestCase):
         )
         self.assertEqual(response.status_code, 200)
 
-    def test_DBに入力したIDとパスワードのレコードを作成する(self):
+    def test_POSTで送信したIDとパスワードでDBにレコードを作成する(self):
         response = self.client.post(
             reverse('ginstagram:registration'), 
             {
@@ -68,3 +68,5 @@ class ユーザー作成機能(TestCase):
         )
         user = Users.objects.last()
         self.assertEqual(user.username, 'TEST_USER_NAME')
+        self.assertEqual(user.password, 'TEST_PASSWORD')
+

--- a/ginstagram/urls.py
+++ b/ginstagram/urls.py
@@ -5,5 +5,5 @@ app_name = 'ginstagram'
 urlpatterns = [
     path('', views.main),
     path('registration/', views.registration, name='registration'),
-    path('<user_name>/', views.profile, name='profile'),
+    path('<username>/', views.profile, name='profile'),
 ]

--- a/ginstagram/views.py
+++ b/ginstagram/views.py
@@ -18,4 +18,5 @@ def registration(request):
     if request.method == 'GET':
         return render(request, 'ginstagram/registration.html')
     elif request.method == 'POST':
+        Users.objects.create(username='TEST_USER_NAME')
         return HttpResponse('POST途中')

--- a/ginstagram/views.py
+++ b/ginstagram/views.py
@@ -18,5 +18,8 @@ def registration(request):
     if request.method == 'GET':
         return render(request, 'ginstagram/registration.html')
     elif request.method == 'POST':
-        Users.objects.create(username='TEST_USER_NAME')
+        Users.objects.create(
+            username=request.POST.get('username'),
+            password=request.POST.get('password'),
+        )
         return HttpResponse('POST途中')

--- a/ginstagram/views.py
+++ b/ginstagram/views.py
@@ -7,9 +7,9 @@ from .models import Users
 def main(request):
     return HttpResponse("Hello!")
 
-def profile(request, user_name):
+def profile(request, username):
     """ ユーザー詳細画面がユーザー名前ごとに生成"""
-    userInfo = get_object_or_404(Users, username=user_name)
+    userInfo = get_object_or_404(Users, username=username)
     return render(request,'ginstagram/profile.html',{
         'userInfo': userInfo
     })
@@ -22,4 +22,4 @@ def registration(request):
             username=request.POST.get('username'),
             password=request.POST.get('password'),
         )
-        return redirect('ginstagram:profile', user_name=user.username)
+        return redirect('ginstagram:profile', username=user.username)

--- a/ginstagram/views.py
+++ b/ginstagram/views.py
@@ -1,4 +1,4 @@
-from django.shortcuts import render, get_object_or_404
+from django.shortcuts import render, get_object_or_404, redirect
 from django.http import HttpResponse
 from django.template import loader
 from django.http.response import HttpResponse
@@ -18,8 +18,8 @@ def registration(request):
     if request.method == 'GET':
         return render(request, 'ginstagram/registration.html')
     elif request.method == 'POST':
-        Users.objects.create(
+        user = Users.objects.create(
             username=request.POST.get('username'),
             password=request.POST.get('password'),
         )
-        return HttpResponse('POST途中')
+        return redirect('ginstagram:profile', user_name=user.username)

--- a/ginstagram/views.py
+++ b/ginstagram/views.py
@@ -15,4 +15,7 @@ def profile(request, user_name):
     })
 
 def registration(request):
-    return render(request, 'ginstagram/registration.html')
+    if request.method == 'GET':
+        return render(request, 'ginstagram/registration.html')
+    elif request.method == 'POST':
+        return HttpResponse('POST途中')


### PR DESCRIPTION
# やったこと

#2 の実装
- [ ] ユーザー作成機能
  - [x] ユーザを作成
    - [x] IDとパスワードが入力できるformを表示する
    - [x] ユーザー名とパスワードをPOSTで送信するとDBに入力したIDとパスワードのレコードを作成する
    - [x] ユーザ作成成功後は作成したユーザ詳細画面にRedirectする

## 残り
  - [ ] validationを作成する
    - [ ] IDの重複は認めないこと
    - [ ] パスワードは8文字以上で英数半角混在以外は認めないこと
    - [ ] validation Errorを表示する
    - [ ] validationに失敗したときは入力情報を保持する    
- [ ] プロフィール編集機能
  - [ ] プロフィール画像をアップロードできること
  - [ ] プロフィール画像が変更できること
- [ ] ユーザープロフィール画面の修正
  - [x] ユーザ詳細画面に作成したIDが表示されていること
  - [ ] ユーザー詳細画面にプロフィール画像が表示できること

## 備考
現段階で仕様にないものを先駆けて実装してテストに支障があったので一旦アイコン表示を消しました。



