### PR TITLE
アイコン画像のアップロード周り

### DIFF
--- a/ginstagram/forms.py
+++ b/ginstagram/forms.py
@@ -29,4 +29,4 @@ class UserIconForm(forms.ModelForm):
         fields = ("icon",)
 
     def clean_icon(self):
-        print(self.cleaned_data.get('icon'))
+        pass

--- a/ginstagram/forms.py
+++ b/ginstagram/forms.py
@@ -27,15 +27,3 @@ class UserIconForm(forms.ModelForm):
     class Meta:
         model = User
         fields = ("icon",)
-
-    def form_valid(self, form):
-        myfile = self.get_form_kwargs().get('files')['icon']
-        fs = FileSystemStorage()
-        filename = fs.save(myfile.name, myfile)
-        path = os.path.join(settings.MEDIA_ROOT, 'image', myfile.name)
-
-        destination = open(path, 'wb')
-        for chunk in myfile.chunks():
-            destination.write(chunk)
-
-

--- a/ginstagram/forms.py
+++ b/ginstagram/forms.py
@@ -28,3 +28,5 @@ class UserIconForm(forms.ModelForm):
         model = User
         fields = ("icon",)
 
+    def clean_icon(self):
+        print(self.cleaned_data.get('icon'))

--- a/ginstagram/forms.py
+++ b/ginstagram/forms.py
@@ -28,5 +28,14 @@ class UserIconForm(forms.ModelForm):
         model = User
         fields = ("icon",)
 
-    def clean_icon(self):
-        pass
+    def form_valid(self, form):
+        myfile = self.get_form_kwargs().get('files')['icon']
+        fs = FileSystemStorage()
+        filename = fs.save(myfile.name, myfile)
+        path = os.path.join(settings.MEDIA_ROOT, 'image', myfile.name)
+
+        destination = open(path, 'wb')
+        for chunk in myfile.chunks():
+            destination.write(chunk)
+
+

--- a/ginstagram/forms.py
+++ b/ginstagram/forms.py
@@ -19,3 +19,12 @@ class UserForm(forms.ModelForm):
         if not re.search(r'[a-zA-Z]', password):
             raise forms.ValidationError('アルファベットが含まれていません')
         return password
+
+
+class UserIconForm(forms.ModelForm):
+    icon = forms.ImageField()
+
+    class Meta:
+        model = User
+        fields = ("icon",)
+

--- a/ginstagram/models.py
+++ b/ginstagram/models.py
@@ -1,7 +1,11 @@
 from django.db import models
 from django.contrib.auth.models import AbstractUser
-
+from django.urls import reverse
 
 class User(AbstractUser):
     """ 既存のユーザーモデルにアイコン情報を追加"""
     icon = models.ImageField(upload_to="image/", blank=True, null=True)
+
+    def get_absolute_url(self):
+        return reverse('ginstagram:profile', kwargs={'username': self.username})
+

--- a/ginstagram/models.py
+++ b/ginstagram/models.py
@@ -2,10 +2,12 @@ from django.db import models
 from django.contrib.auth.models import AbstractUser
 from django.urls import reverse
 
+
 class User(AbstractUser):
     """ 既存のユーザーモデルにアイコン情報を追加"""
     icon = models.ImageField(upload_to="image/", blank=True, null=True)
 
     def get_absolute_url(self):
-        return reverse('ginstagram:profile', kwargs={'username': self.username})
-
+        return reverse(
+            'ginstagram:profile', kwargs={'username': self.username}
+        )

--- a/ginstagram/templates/ginstagram/profile.html
+++ b/ginstagram/templates/ginstagram/profile.html
@@ -6,7 +6,9 @@
   <!-- アカウント情報 -->
   <div class="row">
     <div class="col-md-2 col-md-offset-1">
-
+        <button onclick="javascript:location.href = {% url 'ginstagram:profile' user.username %};">
+            プロフィール画像編集
+        </button>
     </div>
     <div class="col-md-9">
       <div class="col-md-12">

--- a/ginstagram/templates/ginstagram/profile.html
+++ b/ginstagram/templates/ginstagram/profile.html
@@ -6,9 +6,7 @@
   <!-- アカウント情報 -->
   <div class="row">
     <div class="col-md-2 col-md-offset-1">
-        <button onclick="javascript:location.href = '{% url 'ginstagram:icon' user.username %}';">
-            プロフィール画像編集
-        </button>
+        <a class="btn btn-primary" href="{% url 'ginstagram:icon' user.username %}">プロフィール画像編集</a>
     </div>
     <div class="col-md-9">
       <div class="col-md-12">

--- a/ginstagram/templates/ginstagram/profile.html
+++ b/ginstagram/templates/ginstagram/profile.html
@@ -6,7 +6,7 @@
   <!-- アカウント情報 -->
   <div class="row">
     <div class="col-md-2 col-md-offset-1">
-        <button onclick="javascript:location.href = {% url 'ginstagram:profile' user.username %};">
+        <button onclick="javascript:location.href = '{% url 'ginstagram:icon' user.username %}';">
             プロフィール画像編集
         </button>
     </div>

--- a/ginstagram/templates/ginstagram/profile_icon.html
+++ b/ginstagram/templates/ginstagram/profile_icon.html
@@ -1,0 +1,21 @@
+{% extends 'base.html' %}
+{% block title %}Ginstagram{%endblock%}
+{% block content %}
+<div class="container">
+    <div class=" panel panel-primary" >
+        <div class="panel-heading">
+            登録フォーム
+        </div>
+        <div class="panel-body">
+            <form action="{% url 'ginstagram:registration' %}" method="post">
+                {% csrf_token %}
+                {{form}}
+                </div>
+                <div class="form-group">
+                    <button type="submit" class="btn btn-primary">登録</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+{%endblock%}

--- a/ginstagram/templates/ginstagram/profile_icon.html
+++ b/ginstagram/templates/ginstagram/profile_icon.html
@@ -7,7 +7,7 @@
             登録フォーム
         </div>
         <div class="panel-body">
-            <form action="{% url 'ginstagram:icon' username %}" method="post" enctype="multipart/form-data" >
+            <form action="{% url 'ginstagram:icon' user.username %}" method="post" enctype="multipart/form-data" >
                 {% csrf_token %}
                 {{form}}
                 </div>

--- a/ginstagram/templates/ginstagram/profile_icon.html
+++ b/ginstagram/templates/ginstagram/profile_icon.html
@@ -7,7 +7,7 @@
             登録フォーム
         </div>
         <div class="panel-body">
-            <form action="{% url 'ginstagram:icon' user.username %}" method="post" enctype="multipart/form-data" >
+            <form action="{% url 'ginstagram:icon' username %}" method="post" enctype="multipart/form-data" >
                 {% csrf_token %}
                 {{form}}
                 </div>

--- a/ginstagram/templates/ginstagram/profile_icon.html
+++ b/ginstagram/templates/ginstagram/profile_icon.html
@@ -7,7 +7,7 @@
             登録フォーム
         </div>
         <div class="panel-body">
-            <form action="{% url 'ginstagram:registration' %}" method="post">
+            <form action="{% url 'ginstagram:icon' user.username %}" method="post">
                 {% csrf_token %}
                 {{form}}
                 </div>

--- a/ginstagram/templates/ginstagram/profile_icon.html
+++ b/ginstagram/templates/ginstagram/profile_icon.html
@@ -7,7 +7,7 @@
             登録フォーム
         </div>
         <div class="panel-body">
-            <form action="{% url 'ginstagram:icon' user.username %}" method="post">
+            <form action="{% url 'ginstagram:icon' user.username %}" method="post" enctype="multipart/form-data" >
                 {% csrf_token %}
                 {{form}}
                 </div>

--- a/ginstagram/tests/views/test_icon.py
+++ b/ginstagram/tests/views/test_icon.py
@@ -1,6 +1,14 @@
+import io
+from PIL import Image
+
 from django.urls import reverse
 from django.test import TestCase
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.conf import settings
+
 from ginstagram.models import User
+from ginstagram.forms import UserIconForm
+
 
 
 class ユーザーアイコン編集画面表示機能(TestCase):
@@ -42,4 +50,46 @@ class ユーザーアイコン編集画面表示機能(TestCase):
         self.assertContains(
             response,
             'form action="/icon/edit/'+user.username+'/"'
+
         )
+
+    """
+    def test_POSTで送信したIDとパスワードでDBにレコードを作成する(self):
+        user = User.objects.create(
+            username='TEST_USER_NAME',
+        )
+
+        file_obj = io.BytesIO()
+
+        image = Image.new('RGBA', size=(10, 10), color=(256, 0, 0))
+        image.save(file_obj, 'png')
+        file_obj.name = 'image.png'
+        file_obj.seek(0)
+
+        form = UserIconForm(
+            files={'icon': SimpleUploadedFile(
+                file_obj.name,
+                file_obj.read(),
+                content_type='image/png',
+            )},
+        )
+        form.save()
+
+        user = User.objects.last()
+        print(user.icon.name)
+        self.assertEqual(user.icon.name, 'image/image.png')
+
+    """
+    def test_Postで画像が送信できるかテスト(self):
+        user = User.objects.create(
+            username='TEST_USER_NAME',
+        )
+
+        with open(settings.MEDIA_ROOT + '/image/image.jpg', 'rb') as f:
+            response = self.client.post(
+                reverse('ginstagram:icon', args=[user.username]),
+                {'icon': f}
+            )
+        print(response)
+        user = User.objects.last()
+        self.assertEqual(response.status_code, 200)

--- a/ginstagram/tests/views/test_icon.py
+++ b/ginstagram/tests/views/test_icon.py
@@ -1,0 +1,21 @@
+from django.urls import reverse
+from django.test import TestCase
+from ginstagram.models import User
+
+
+class ユーザーアイコン編集画面表示機能(TestCase):
+
+    def test_ユーザープロフィール画面にプロフィール編集画面へのリンクを表示すること(self):
+        user = User.objects.create(
+            username='TEST_USER_NAME',
+            icon='image/image.jpg',
+        )
+        response = self.client.get(
+            reverse('ginstagram:profile', args=[user.username])
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'プロフィール画像編集')
+        self.assertContains(
+            response,
+            reverse('ginstagram:profile' , kwargs={'username': user.username})
+        )

--- a/ginstagram/tests/views/test_icon.py
+++ b/ginstagram/tests/views/test_icon.py
@@ -57,7 +57,7 @@ class ユーザーアイコン編集画面表示機能(TestCase):
         user = User.objects.create(
             username='TEST_USER_NAME',
         )
-        with open(settings.MEDIA_ROOT + '/image/iwauchi.png', 'rb') as f:
+        with open(settings.MEDIA_ROOT + '/image/image.jpg', 'rb') as f:
             response = self.client.post(
                 reverse('ginstagram:icon', args=[user.username]),
                 {'icon': f}

--- a/ginstagram/tests/views/test_icon.py
+++ b/ginstagram/tests/views/test_icon.py
@@ -1,14 +1,8 @@
-import io
-from PIL import Image
-
 from django.urls import reverse
 from django.test import TestCase
-from django.core.files.uploadedfile import SimpleUploadedFile
 from django.conf import settings
 
 from ginstagram.models import User
-from ginstagram.forms import UserIconForm
-
 
 
 class ユーザーアイコン編集画面表示機能(TestCase):
@@ -25,7 +19,7 @@ class ユーザーアイコン編集画面表示機能(TestCase):
         self.assertContains(response, 'プロフィール画像編集')
         self.assertContains(
             response,
-            reverse('ginstagram:icon' , kwargs={'username': user.username})
+            reverse('ginstagram:icon', kwargs={'username': user.username})
         )
 
     def test_画像アップロード用のフォームが表示されること(self):

--- a/ginstagram/tests/views/test_icon.py
+++ b/ginstagram/tests/views/test_icon.py
@@ -37,18 +37,6 @@ class ユーザーアイコン編集画面表示機能(TestCase):
 
         )
 
-    def test_Postで画像が送信できるかテスト(self):
-        user = User.objects.create(
-            username='TEST_USER_NAME',
-        )
-        with open(settings.MEDIA_ROOT + '/image/image.jpg', 'rb') as f:
-            response = self.client.post(
-                reverse('ginstagram:icon', args=[user.username]),
-                {'icon': f}
-            )
-        user = User.objects.last()
-        self.assertEqual(response.status_code, 302)
-
     def test_POSTで送信したIDとパスワードでDBにレコードを作成する(self):
         user = User.objects.create(
             username='TEST_USER_NAME',

--- a/ginstagram/tests/views/test_icon.py
+++ b/ginstagram/tests/views/test_icon.py
@@ -12,21 +12,6 @@ from ginstagram.forms import UserIconForm
 
 class ユーザーアイコン編集画面表示機能(TestCase):
 
-    def test_ユーザープロフィール画面にプロフィール編集画面へのリンクを表示すること(self):
-        user = User.objects.create(
-            username='TEST_USER_NAME',
-            icon='image/image.jpg',
-        )
-        response = self.client.get(
-            reverse('ginstagram:profile', args=[user.username])
-        )
-        self.assertEqual(response.status_code, 200)
-        self.assertContains(response, 'プロフィール画像編集')
-        self.assertContains(
-            response,
-            reverse('ginstagram:icon', kwargs={'username': user.username})
-        )
-
     def test_画像アップロード用のフォームが表示されること(self):
         user = User.objects.create(
             username='TEST_USER_NAME',

--- a/ginstagram/tests/views/test_icon.py
+++ b/ginstagram/tests/views/test_icon.py
@@ -53,43 +53,14 @@ class ユーザーアイコン編集画面表示機能(TestCase):
 
         )
 
-    """
-    def test_POSTで送信したIDとパスワードでDBにレコードを作成する(self):
-        user = User.objects.create(
-            username='TEST_USER_NAME',
-        )
-
-        file_obj = io.BytesIO()
-
-        image = Image.new('RGBA', size=(10, 10), color=(256, 0, 0))
-        image.save(file_obj, 'png')
-        file_obj.name = 'image.png'
-        file_obj.seek(0)
-
-        form = UserIconForm(
-            files={'icon': SimpleUploadedFile(
-                file_obj.name,
-                file_obj.read(),
-                content_type='image/png',
-            )},
-        )
-        form.save()
-
-        user = User.objects.last()
-        print(user.icon.name)
-        self.assertEqual(user.icon.name, 'image/image.png')
-
-    """
     def test_Postで画像が送信できるかテスト(self):
         user = User.objects.create(
             username='TEST_USER_NAME',
         )
-
-        with open(settings.MEDIA_ROOT + '/image/image.jpg', 'rb') as f:
+        with open(settings.MEDIA_ROOT + '/image/iwauchi.png', 'rb') as f:
             response = self.client.post(
                 reverse('ginstagram:icon', args=[user.username]),
                 {'icon': f}
             )
-        print(response)
         user = User.objects.last()
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 302)

--- a/ginstagram/tests/views/test_icon.py
+++ b/ginstagram/tests/views/test_icon.py
@@ -1,8 +1,13 @@
+import io
+from PIL import Image
+
 from django.urls import reverse
 from django.test import TestCase
 from django.conf import settings
+from django.core.files.uploadedfile import SimpleUploadedFile
 
 from ginstagram.models import User
+from ginstagram.forms import UserIconForm
 
 
 class ユーザーアイコン編集画面表示機能(TestCase):
@@ -58,3 +63,26 @@ class ユーザーアイコン編集画面表示機能(TestCase):
             )
         user = User.objects.last()
         self.assertEqual(response.status_code, 302)
+
+    def test_POSTで送信したIDとパスワードでDBにレコードを作成する(self):
+        user = User.objects.create(
+            username='TEST_USER_NAME',
+        )
+
+        file_obj = io.BytesIO()
+        image = Image.new('RGBA', size=(10, 10), color=(256, 0, 0))
+        image.save(file_obj, 'png')
+        file_obj.name = 'TEST_USER_ICON.jpg'
+        file_obj.seek(0)
+
+        form = UserIconForm(
+            files={'icon': SimpleUploadedFile(
+                file_obj.name,
+                file_obj.read(),
+                content_type='image/jpg',
+            )},
+        )
+        form.save()
+
+        user = User.objects.last()
+        self.assertEqual(user.icon.name, 'image/TEST_USER_ICON.jpg')

--- a/ginstagram/tests/views/test_icon.py
+++ b/ginstagram/tests/views/test_icon.py
@@ -28,4 +28,18 @@ class ユーザーアイコン編集画面表示機能(TestCase):
         response = self.client.get(
             reverse('ginstagram:icon', args=[user.username])
         )
+        self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'form')
+
+    def test_フォームタグにユーザー名が含まれている(self):
+        user = User.objects.create(
+            username='TEST_USER_NAME',
+            icon='image/image.jpg',
+        )
+        response = self.client.get(
+            reverse('ginstagram:icon', args=[user.username])
+        )
+        self.assertContains(
+            response,
+            'form action="/icon/edit/'+user.username+'/"'
+        )

--- a/ginstagram/tests/views/test_icon.py
+++ b/ginstagram/tests/views/test_icon.py
@@ -17,5 +17,15 @@ class ユーザーアイコン編集画面表示機能(TestCase):
         self.assertContains(response, 'プロフィール画像編集')
         self.assertContains(
             response,
-            reverse('ginstagram:profile' , kwargs={'username': user.username})
+            reverse('ginstagram:icon' , kwargs={'username': user.username})
         )
+
+    def test_画像アップロード用のフォームが表示されること(self):
+        user = User.objects.create(
+            username='TEST_USER_NAME',
+            icon='image/image.jpg',
+        )
+        response = self.client.get(
+            reverse('ginstagram:icon', args=[user.username])
+        )
+        self.assertContains(response, 'form')

--- a/ginstagram/tests/views/test_profile.py
+++ b/ginstagram/tests/views/test_profile.py
@@ -15,3 +15,20 @@ class ユーザー詳細表示機能(TestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, user.username)
+
+    def test_ユーザープロフィール画面にプロフィール編集画面へのリンクを表示すること(self):
+        user = User.objects.create(
+            username='TEST_USER_NAME',
+            icon='image/image.jpg',
+        )
+        response = self.client.get(
+            reverse('ginstagram:profile', args=[user.username])
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'プロフィール画像編集')
+        self.assertContains(
+            response,
+            reverse('ginstagram:icon', kwargs={'username': user.username})
+        )
+
+

--- a/ginstagram/urls.py
+++ b/ginstagram/urls.py
@@ -5,5 +5,5 @@ app_name = 'ginstagram'
 urlpatterns = [
     path('registration/', views.Registration.as_view(), name='registration'),
     path('<username>/', views.Profile.as_view(), name='profile'),
-    path('icon/edit/<username>/', views.upload_file,  name='icon'),
+    path('icon/edit/<username>/', views.ProfileIcon.as_view(),  name='icon'),
 ]

--- a/ginstagram/urls.py
+++ b/ginstagram/urls.py
@@ -5,5 +5,5 @@ app_name = 'ginstagram'
 urlpatterns = [
     path('registration/', views.Registration.as_view(), name='registration'),
     path('<username>/', views.Profile.as_view(), name='profile'),
-    path('icon/edit/<username>/', views.ProfileIcon.as_view(),  name='icon'),
+    path('<username>/icon/edit/', views.ProfileIcon.as_view(),  name='icon'),
 ]

--- a/ginstagram/urls.py
+++ b/ginstagram/urls.py
@@ -5,5 +5,5 @@ app_name = 'ginstagram'
 urlpatterns = [
     path('registration/', views.Registration.as_view(), name='registration'),
     path('<username>/', views.Profile.as_view(), name='profile'),
-    path('icon/edit/<username>/', views.ProfileIcon.as_view(), name='icon'),
+    path('icon/edit/<username>/', views.upload_file,  name='icon'),
 ]

--- a/ginstagram/urls.py
+++ b/ginstagram/urls.py
@@ -5,4 +5,5 @@ app_name = 'ginstagram'
 urlpatterns = [
     path('registration/', views.Registration.as_view(), name='registration'),
     path('<username>/', views.Profile.as_view(), name='profile'),
+    path('icon/edit/<username>/', views.ProfileIcon.as_view(), name='icon'),
 ]

--- a/ginstagram/views.py
+++ b/ginstagram/views.py
@@ -3,7 +3,7 @@ import os
 from django.views import generic
 from django.urls import reverse
 from django.core.files.storage import FileSystemStorage
-from django.shortcuts import get_object_or_404, render
+from django.shortcuts import get_object_or_404, render, redirect
 from django.conf import settings
 
 from .models import User
@@ -43,6 +43,7 @@ class ProfileIcon(generic.edit.UpdateView):
 
 
 def upload_file(request, username):
+    user = User.objects.get(username=username)
     if request.method == 'POST':
         form = UserIconForm(request.POST, request.FILES)
         if form.is_valid():
@@ -55,9 +56,17 @@ def upload_file(request, username):
             for chunk in myfile.chunks():
                 destination.write(chunk)
 
-        return render(request, 'ginstagram/profile_icon.html', {'username': username, 'form': form})
+            user.icon = myfile
+            user.save()
+
+        return redirect(
+            reverse(
+                'ginstagram:profile',
+                kwargs={'username': user.username}
+            ),
+            {'form':form}
+        )
     else:
         form = UserIconForm()
-    return render(request, 'ginstagram/profile_icon.html', {'username': username, 'form': form})
-
-
+    return render(request, 'ginstagram/profile_icon.html', 
+            {'username': username, 'user':user, 'form': form})

--- a/ginstagram/views.py
+++ b/ginstagram/views.py
@@ -1,10 +1,5 @@
-import os
-
 from django.views import generic
 from django.urls import reverse
-from django.core.files.storage import FileSystemStorage
-from django.shortcuts import get_object_or_404, render, redirect
-from django.conf import settings
 
 from .models import User
 from .forms import UserForm, UserIconForm

--- a/ginstagram/views.py
+++ b/ginstagram/views.py
@@ -28,7 +28,9 @@ class Registration(generic.edit.FormView):
         )
 
 
-class ProfileIcon(generic.edit.FormView):
+class ProfileIcon(generic.edit.UpdateView):
     model = User
     template_name = 'ginstagram/profile_icon.html'
     form_class = UserIconForm
+    slug_field = 'username'
+    slug_url_kwarg = 'username'

--- a/ginstagram/views.py
+++ b/ginstagram/views.py
@@ -34,3 +34,4 @@ class ProfileIcon(generic.edit.UpdateView):
     form_class = UserIconForm
     slug_field = 'username'
     slug_url_kwarg = 'username'
+

--- a/ginstagram/views.py
+++ b/ginstagram/views.py
@@ -1,7 +1,7 @@
 from django.views import generic
 from django.urls import reverse
 from .models import User
-from .forms import UserForm
+from .forms import UserForm, UserIconForm
 
 
 class Profile(generic.DetailView):
@@ -26,3 +26,9 @@ class Registration(generic.edit.FormView):
             'ginstagram:profile',
             kwargs={'username': form.data.get('username')}
         )
+
+
+class ProfileIcon(generic.edit.FormView):
+    model = User
+    template_name = 'ginstagram/profile_icon.html'
+    form_class = UserIconForm

--- a/ginstagram/views.py
+++ b/ginstagram/views.py
@@ -3,7 +3,7 @@ import os
 from django.views import generic
 from django.urls import reverse
 from django.core.files.storage import FileSystemStorage
-from django.shortcuts import get_object_or_404, render
+from django.shortcuts import get_object_or_404, render, redirect
 from django.conf import settings
 
 from .models import User
@@ -59,7 +59,7 @@ def upload_file(request, username):
             user.icon = myfile
             user.save()
 
-        return render(request, 'ginstagram/profile_icon.html', {'username': username, 'form': form})
+        return redirect('ginstagram:profile', username=username)
     else:
         form = UserIconForm()
     return render(request, 'ginstagram/profile_icon.html', {'username': username, 'form': form})

--- a/ginstagram/views.py
+++ b/ginstagram/views.py
@@ -1,5 +1,11 @@
+import os
+
 from django.views import generic
 from django.urls import reverse
+from django.core.files.storage import FileSystemStorage
+from django.shortcuts import get_object_or_404, render
+from django.conf import settings
+
 from .models import User
 from .forms import UserForm, UserIconForm
 
@@ -34,4 +40,24 @@ class ProfileIcon(generic.edit.UpdateView):
     form_class = UserIconForm
     slug_field = 'username'
     slug_url_kwarg = 'username'
+
+
+def upload_file(request, username):
+    if request.method == 'POST':
+        form = UserIconForm(request.POST, request.FILES)
+        if form.is_valid():
+            myfile = request.FILES['icon']
+            fs = FileSystemStorage()
+            filename = fs.save(myfile.name, myfile)
+            path = os.path.join(settings.MEDIA_ROOT, 'image', myfile.name)
+
+            destination = open(path, 'wb')
+            for chunk in myfile.chunks():
+                destination.write(chunk)
+
+        return render(request, 'ginstagram/profile_icon.html', {'username': username, 'form': form})
+    else:
+        form = UserIconForm()
+    return render(request, 'ginstagram/profile_icon.html', {'username': username, 'form': form})
+
 

--- a/ginstagram/views.py
+++ b/ginstagram/views.py
@@ -3,7 +3,7 @@ import os
 from django.views import generic
 from django.urls import reverse
 from django.core.files.storage import FileSystemStorage
-from django.shortcuts import get_object_or_404, render, redirect
+from django.shortcuts import get_object_or_404, render
 from django.conf import settings
 
 from .models import User
@@ -43,7 +43,6 @@ class ProfileIcon(generic.edit.UpdateView):
 
 
 def upload_file(request, username):
-    user = User.objects.get(username=username)
     if request.method == 'POST':
         form = UserIconForm(request.POST, request.FILES)
         if form.is_valid():
@@ -56,17 +55,13 @@ def upload_file(request, username):
             for chunk in myfile.chunks():
                 destination.write(chunk)
 
+            user = User.objects.get(username=username)
             user.icon = myfile
             user.save()
 
-        return redirect(
-            reverse(
-                'ginstagram:profile',
-                kwargs={'username': user.username}
-            ),
-            {'form':form}
-        )
+        return render(request, 'ginstagram/profile_icon.html', {'username': username, 'form': form})
     else:
         form = UserIconForm()
-    return render(request, 'ginstagram/profile_icon.html', 
-            {'username': username, 'user':user, 'form': form})
+    return render(request, 'ginstagram/profile_icon.html', {'username': username, 'form': form})
+
+

--- a/ginstagram/views.py
+++ b/ginstagram/views.py
@@ -40,28 +40,3 @@ class ProfileIcon(generic.edit.UpdateView):
     form_class = UserIconForm
     slug_field = 'username'
     slug_url_kwarg = 'username'
-
-
-def upload_file(request, username):
-    if request.method == 'POST':
-        form = UserIconForm(request.POST, request.FILES)
-        if form.is_valid():
-            myfile = request.FILES['icon']
-            fs = FileSystemStorage()
-            filename = fs.save(myfile.name, myfile)
-            path = os.path.join(settings.MEDIA_ROOT, 'image', myfile.name)
-
-            destination = open(path, 'wb')
-            for chunk in myfile.chunks():
-                destination.write(chunk)
-
-            user = User.objects.get(username=username)
-            user.icon = myfile
-            user.save()
-
-        return redirect('ginstagram:profile', username=username)
-    else:
-        form = UserIconForm()
-    return render(request, 'ginstagram/profile_icon.html', {'username': username, 'form': form})
-
-

--- a/ginstagram/views.py
+++ b/ginstagram/views.py
@@ -15,7 +15,6 @@ class Profile(generic.DetailView):
 class Registration(generic.edit.CreateView):
     template_name = 'ginstagram/registration.html'
     form_class = UserForm
-    success_url = '/'
 
     def get_success_url(self):
         form = self.get_form()

--- a/ginstagram/views.py
+++ b/ginstagram/views.py
@@ -17,14 +17,10 @@ class Profile(generic.DetailView):
     slug_url_kwarg = 'username'
 
 
-class Registration(generic.edit.FormView):
+class Registration(generic.edit.CreateView):
     template_name = 'ginstagram/registration.html'
     form_class = UserForm
     success_url = '/'
-
-    def form_valid(self, form):
-        form.save()
-        return super().form_valid(form)
 
     def get_success_url(self):
         form = self.get_form()


### PR DESCRIPTION
## やったこと
#2 
- [x] CreateViewの利用

- [x] プロフィール編集機能
  - [x] プロフィール画像をアップロードできること
    - [x] ユーザープロフィール画面にプロフィール編集画面へのリンクを表示すること
    - [x] 画像アップロード用のフォームが表示されること
    - [x] アップロードしたユーザーのレコードに追加されること

## やってないこと
- [ ] ユーザープロフィール画面の修正
  - [x] ユーザ詳細画面に作成したIDが表示されていること
  - [ ] ユーザー詳細画面にプロフィール画像が表示できること
  - [ ] プロフィール画像が変更できること
    - [ ] すでにある状態で画像アップロードしたら新しい画像に変更される 