### PR TITLE
ユーザーの保持する画像をプロフィールに表示するためのブランチ

### DIFF
--- a/ginstagram/templates/ginstagram/profile.html
+++ b/ginstagram/templates/ginstagram/profile.html
@@ -6,6 +6,9 @@
   <!-- アカウント情報 -->
   <div class="row">
     <div class="col-md-2 col-md-offset-1">
+        {% if user.icon %}
+        <img src="{{user.icon.url}}" class="ginstagram-icon img-responsive ">
+        {% endif %}
         <button onclick="javascript:location.href = '{% url 'ginstagram:icon' user.username %}';">
             プロフィール画像編集
         </button>

--- a/ginstagram/templates/ginstagram/registration.html
+++ b/ginstagram/templates/ginstagram/registration.html
@@ -11,7 +11,11 @@
                 {% csrf_token %}
                 <div class="form-group">
                     <label for="username">ユーザーネーム</label>
+                    {% if form.username.value %}
                     <input type="text" name="username" id="username" value="{{ form.username.value }} " />
+                    {% else  %}
+                    <input type="text" name="username" id="username" />
+                    {% endif %}
                     {% if form.username.errors %}
                     <div class="alert alert-danger">
                         {{ form.username.errors }}

--- a/ginstagram/tests/views/test_icon.py
+++ b/ginstagram/tests/views/test_icon.py
@@ -46,7 +46,7 @@ class ユーザーアイコン編集画面表示機能(TestCase):
         )
         self.assertContains(
             response,
-            'form action="/'+user.username+'/icon/edit/"'
+            f'form action="/{user.username}/icon/edit/"'
         )
 
     def test_POSTで送信したIDとパスワードでDBにレコードを作成する(self):

--- a/ginstagram/tests/views/test_profile.py
+++ b/ginstagram/tests/views/test_profile.py
@@ -1,5 +1,6 @@
 from django.urls import reverse
 from django.test import TestCase
+
 from ginstagram.models import User
 
 

--- a/ginstagram/views.py
+++ b/ginstagram/views.py
@@ -15,7 +15,6 @@ class Profile(generic.DetailView):
 class Registration(generic.edit.CreateView):
     template_name = 'ginstagram/registration.html'
     form_class = UserForm
-    success_url = '/'
 
     def get_success_url(self):
         form = self.get_form()


### PR DESCRIPTION
# TODO

- [x]  マージ前にマスターに変更

## やったこと

- [x] ユーザープロフィール画面の修正
  - [x] ユーザ詳細画面に作成したIDが表示されていること
  - [x] ユーザー詳細画面にプロフィール画像が表示できること
  - [x] プロフィール画像が変更できること
    - [x] すでにある状態で画像アップロードしたら新しい画像に変更される 

## キャプチャ
![image](https://user-images.githubusercontent.com/20414863/40763989-1cd4b73a-64e2-11e8-9107-12cb100a487c.png)
